### PR TITLE
Fehler der REX_LINKLIST ausgabe

### DIFF
--- a/redaxo-variablen.md
+++ b/redaxo-variablen.md
@@ -149,8 +149,8 @@ REX_LINKLIST[id=1 widget=1]
 **Beispiel in der Modul-Ausgabe**
 
 ```
-<?php foreach (explode(',', REXLINKLIST[id=1]) as $article_id): ?>
-<a href="<?=rex_getUrl(article_id);?>">zum Artikel mit der ID <?=article_id;?></a>
+<?php foreach (explode(',', 'REX_LINKLIST[id=1]') as $article_id): ?>
+<a href="<?=rex_getUrl($article_id);?>">zum Artikel mit der ID <?=$article_id;?></a>
 <?php endforeach;?>
 ```
 


### PR DESCRIPTION
Da haben sich ein paar Fehler eingeschlichen, richtig wäre:
(Schreibweise von REX_LINKLIST, REX_LINKLIST als String in die explode-Methode, $article_id statt article_id)

Issue welches ich angelegt hatte, da ich nicht wusste wie ich den PR hinbekomme:
#54