### PR TITLE
Neuen EP MEDIA_ADD dokumentieren

### DIFF
--- a/extension-points.md
+++ b/extension-points.md
@@ -482,10 +482,6 @@ MEDIA_ADDED
 : Daten: keine
 : Parameter: $RETURN
 
-MEDIA_ADDED
-: Daten: keine
-: Parameter: $return
-
 MEDIA_DELETED
 : Daten: keine
 : Parameter: ['filename' => $filename]

--- a/extension-points.md
+++ b/extension-points.md
@@ -478,6 +478,10 @@ STRUCTURE_CONTENT_SLICE_UPDATED
 ### Medienpool
 
 ```
+MEDIA_ADD
+: Daten: $ERROR_MSG
+: Parameter: ['file' => $FILE, 'title' => $FILEINFOS['title'], 'filename' => $NFILENAME, 'old_filename' => $FILENAME, 'is_upload' => $isFileUpload 'category_id' => $rex_file_category, 'type' => $FILETYPE]
+
 MEDIA_ADDED
 : Daten: keine
 : Parameter: $RETURN


### PR DESCRIPTION
Der PR [#3657](https://github.com/redaxo/redaxo/pull/3657) hat Redaxo um den Extension Point `MEDIA_ADD` erweitert. Durch diesen PR wird er auch der Dokumentation hinzugefügt.