### PR TITLE
Fehler in Zustrom Breadcrumb korrigiert

### DIFF
--- a/navigationen.md
+++ b/navigationen.md
@@ -298,7 +298,7 @@ $parent = $article->getParentTree();
 $breadcrumb = '<ul>';
 
     // Startartikel als Erstes anzeigen
-    $breadcrumb .= '<li><a href="'.rex_getUrl(rex_article::getSiteStartArticle()).'">Start</a></li>';
+    $breadcrumb .= '<li><a href="'.rex_getUrl(rex_article::getSiteStartArticleId()).'">Start</a></li>';
 
     // rekursiv den Kategoriebaum der gerade aktiven Kategorien durchlaufen
     foreach($parent as $cat) {


### PR DESCRIPTION
rex_getUrl(rex_article::getSiteStartArticle() -> rex_getUrl(rex_article::getSiteStartArticleId()