### PR TITLE
Update navigationen.md

### DIFF
--- a/navigationen.md
+++ b/navigationen.md
@@ -431,7 +431,7 @@ if ($cats) {
             $catName = $cat->getName(); // Name der Kategorie
             $catUrl =  rex_getUrl($catId); // Url anhand ID ermitteln
             // Zwischenspeichern des Ergebnisses
-            $catoutput .= '<li><a href="' . $catUrl . '">' . $catName . '<a></li>' . "\n";
+            $catoutput .= '<li><a href="' . $catUrl . '">' . $catName . '</a></li>' . "\n";
         }
     }
     echo '<ul class="catlist">' . $catoutput . '</ul>';


### PR DESCRIPTION
cc Oliver Hinz
Moin moin. In der Doku (https://redaxo.org/doku/main/navigationen#custom-artikellisten) gibt es einen Fehler bei "Kategorieliste einer festgelegten Kategorie" > "Modulausgabe". In Zeile 14 wird der <a> Tag nicht geschlossen. LG Oli