### PR TITLE
whoops bildbeschreibung verwenden

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -38,9 +38,7 @@ Wenn ein Administrator eingeloggt ist, oder der Administrator den Debug-Modus ak
 
 > Tritt ein Fehler auf, meldet REDAXO sich im Frontend mit einem Ooops und im Backend mit einem Rrrrroar.
 
-![Whoops](/assets/v5.10.0-debug_whooops.png)
-
-> Whoops-Fehlerseite mit Debug-Informationen
+![Whoops](/assets/v5.10.0-debug_whooops.png) Whoops-Fehlerseite mit Debug-Informationen
 
 Die Whoops-Meldung liefert die Codestellen und Fehlermeldungen zum aufgetretnenen Fehler. Die Infos können zudem kopiert werden. 
 


### PR DESCRIPTION
statt einer "warning/info" box

IST
<img width="1168" alt="grafik" src="https://user-images.githubusercontent.com/120441/222958416-ae7e2860-80df-4a37-8cc9-b7f4038d069e.png">

sollten wir eine bildunterschrift verwenden, sodass auch klar ist, dass der text sich auf den screenshot bezieht - ähnlich wie es auf der gleichen seite weiter oben gelöst ist:

<img width="1169" alt="grafik" src="https://user-images.githubusercontent.com/120441/222958469-52dd72bb-3e09-4507-89c0-9aa6b9ce691a.png">


Ungetestet