### PR TITLE
bildbeschreibung verwenden

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -106,9 +106,7 @@ Das Debug-AddOn kann zusätzlich installiert werden kann und anschließend im Fr
 
 > Das Debug-AddOn sollte nicht in Produktivumgebungen eingesetzt werden, weil hierfür der Debug-Modus im System aktiviert sein muss. Bei Multidomain-Umgebungen sollte man sich mit der gewünschten Domain im Backend einloggen, damit es unter der jeweiligen Domain eingesetzt werden kann.
 
-![Debug-AddOn ab REDAXO 5.11](/assets/v5.11.0-debug_addon.png)
-
-Serverseitige Abläufe visualisiert durch Clockwork
+![Debug-AddOn ab REDAXO 5.11](/assets/v5.11.0-debug_addon.png) Serverseitige Abläufe visualisiert durch Clockwork
 
 Um eigene Messungen vornehmen zu können, kann die rex_timer-Klasse verwendet werden und den eigenen Code dazwischen einfügen:
 


### PR DESCRIPTION
analog https://github.com/redaxo/docs/pull/265, reguläre bildbeschreibung verwenden